### PR TITLE
fix: symbol fallback is not a string

### DIFF
--- a/lua/jabs.lua
+++ b/lua/jabs.lua
@@ -98,7 +98,7 @@ function M.parseLs(buf)
 				end)
 
 				-- Fixes #3
-				symbol = symbol or M.bufinfo['h']
+				symbol = symbol or M.bufinfo['h'][1]
 
 				line = '· '..symbol..' '..line
 			-- Other non-empty splits (filename, RO, modified, ...)


### PR DESCRIPTION
Hello, I had a similar problem as #3 and was glad to see #4 but I still had the issue so I thought I'd make a PR that fixed the issue for me (if you want it) 🙂 

Thanks for this plugin! 😄 