### PR TITLE
Rename command  `JABSOpen` to `JABS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ use 'matbme/JABS.nvim'
 
 ## Usage
 
-As previously mentioned, JABS only has one command: `:JABSOpen`, which opens JABS' window.
+As previously mentioned, JABS only has one command: `:JABS`, which toggles the JABS popup.
 
 By default, you can navigate between buffers with `j` and `k` as well as `<Tab>` and `<S-Tab>`, and jump to a buffer with `<CR>`. When switching buffers the window closes automatically, but it can also be closed with `<Esc>` or `q`.
 

--- a/plugin/jabs.vim
+++ b/plugin/jabs.vim
@@ -1,1 +1,1 @@
-command JABSOpen execute "lua require'jabs'.open()"
+command JABS execute "lua require'jabs'.open()"


### PR DESCRIPTION
I feel that using `JABS` as this command's alias would be better because the command **toggles** JABS rather than just opening it.