### PR TITLE
Use enter instead of space for jump mapping in sample config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ require 'jabs'.setup {
     -- Keymaps
     keymap = {
         close = "<c-d>", -- Close buffer. Default D
-        jump = "<space>", -- Jump to buffer. Default <cr>
+        jump = "<cr>", -- Jump to buffer. Default <cr>
         h_split = "h", -- Horizontally split buffer. Default s
         v_split = "v", -- Vertically split buffer. Default v
         preview = "p", -- Open buffer preview. Default P


### PR DESCRIPTION
Use <kbd>Enter</kbd>instead of <kbd>Space</kbd>for jump mapping because space will conflict if `mapleader` is set to <kbd>Space</kbd>(used by a lot of people as opposed to <kbd>\\</kbd> or <kbd>,</kbd>).